### PR TITLE
image: add range-over points example

### DIFF
--- a/image/main.go
+++ b/image/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"image"
+	"iter"
+)
+
+func Points(img image.Image) iter.Seq[image.Point] {
+	return func(yield func(image.Point) bool) {
+		bounds := img.Bounds()
+		for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+			for x := bounds.Min.X; x < bounds.Max.X; x++ {
+				if !yield(image.Point{X: x, Y: y}) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/image/main_test.go
+++ b/image/main_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"image"
+)
+
+func ExamplePoints() {
+	img := image.NewRGBA(image.Rectangle{
+		Min: image.Point{X: 2, Y: 5},
+		Max: image.Point{X: 5, Y: 8},
+	})
+
+	for p := range Points(img) {
+		fmt.Println(p)
+		// eg. r, g, b, a := img.At(p.X, p.Y).RGBA()
+	}
+
+	// Output: (2,5)
+	// (3,5)
+	// (4,5)
+	// (2,6)
+	// (3,6)
+	// (4,6)
+	// (2,7)
+	// (3,7)
+	// (4,7)
+}


### PR DESCRIPTION
This PR adds an example that demonstrates how to iterate over image points using rangefunc. 
Given that [image.Bounds does not always start at \(0, 0\)](https://cs.opensource.google/go/go/+/refs/tags/go1.22.6:src/image/decode_example_test.go;l=50), this example is, in my opinion, useful in avoiding potential misuse.